### PR TITLE
Provide `salt-api`'s configuration defaults. Refs #52.

### DIFF
--- a/saltapi/config.py
+++ b/saltapi/config.py
@@ -2,11 +2,15 @@
 Manage configuration files in salt-api
 '''
 
-# Import python libs
-import os
-
 # Import salt libs
 import salt.config
+
+DEFAULT_API_OPTS = {
+    # ----- Salt master settings overridden by Salt-API --------------------->
+    'pidfile': '/var/run/salt-api.pid',
+    'logfile': '/var/log/api',
+    # <---- Salt master settings overridden by Salt-API ----------------------
+}
 
 
 def api_config(path):
@@ -14,11 +18,9 @@ def api_config(path):
     Read in the salt master config file and add additional configs that
     need to be stubbed out for salt-api
     '''
-    opts = {}
+    # Let's grab a copy of salt's master default opts
+    defaults = salt.config.DEFAULT_MASTER_OPTS
+    # Let's override them with salt-api's required defaults
+    defaults.update(DEFAULT_API_OPTS)
 
-    opts = salt.config.master_config(path)
-
-    if 'include' in opts:
-        opts = salt.config.include_config(opts, path)
-
-    return opts
+    return salt.config.master_config(path, defaults=defaults)


### PR DESCRIPTION
We now override the necessary keys to adapt the salt-master default configuration to salt-api and feed that to `salt.config.master_config`.
There no need to do our own `include` code since that's also done in `salt.config.master_config`.
