### PR TITLE
Add user wildcard support for perms lookup on login

### DIFF
--- a/saltapi/netapi/rest_cherrypy/app.py
+++ b/saltapi/netapi/rest_cherrypy/app.py
@@ -816,7 +816,7 @@ class Login(LowDataAdapter):
         cherrypy.session['timeout'] = (token['expire'] - token['start']) / 60
 
         # Grab eauth config for the current backend for the current user
-        perms = self.opts['external_auth'][token['eauth']][token['name']]
+        perms = self.opts['external_auth'][token['eauth']][token['name']] if token['name'] in self.opts['external_auth'][token['eauth']] else self.opts['external_auth'][token['eauth']]['*'] 
 
         return {'return': [{
             'token': cherrypy.session.id,


### PR DESCRIPTION
This is to add support in salt-api for this workaround from https://github.com/saltstack/salt/pull/4547.

/etc/salt/master:

```
external_auth:
  ldap:
    '*': 
      - .*
```

Successful login:

```
HTTP/1.1 200 OK
Content-Length: 248
Vary: Accept-Encoding
X-Auth-Token: 1ea3b72edbb66330ef1e12adcc0ce703f0d27231
Allow: GET, HEAD, POST
Date: Sat, 20 Apr 2013 14:28:17 GMT
Server: CherryPy/3.2.2
Content-Type: application/json
Set-Cookie: session_id=1ea3b72edbb66330ef1e12adcc0ce703f0d27231; expires=Sun, 21 Apr 2013 00:28:17 GMT; Path=/

{"return": [{"perms": [".*"], "start": 1366468097.403254, "token": "1ea3b72edbb66330ef1e12adcc0ce703f0d27231", "expire": 1366511297.403255, "user": "gigantor-kingpin1@ENG.SALESFORCE.COM-salt-bc783bc6-8e88-47ba-bb85-005e63025ab6", "eauth": "ldap"}]}
```
