### PR TITLE
Added ability to specify the host address to start the server on

### DIFF
--- a/saltapi/netapi/rest_cherrypy/__init__.py
+++ b/saltapi/netapi/rest_cherrypy/__init__.py
@@ -92,7 +92,7 @@ def start():
                 apiopts['ssl_crt'], apiopts['ssl_key'])
         wsgi_d = wsgiserver.WSGIPathInfoDispatcher({'/': application})
         server = wsgiserver.CherryPyWSGIServer(
-                ('0.0.0.0', apiopts['port']),
+                (apiopts['host'], apiopts['port']),
                 wsgi_app=wsgi_d)
         server.ssl_adapter = ssl_a
 

--- a/saltapi/netapi/rest_cherrypy/app.py
+++ b/saltapi/netapi/rest_cherrypy/app.py
@@ -900,7 +900,7 @@ class API(object):
         '''
         conf = {
             'global': {
-                'server.socket_host': '0.0.0.0',
+                'server.socket_host': apiopts.get('host', '0.0.0.0'),
                 'server.socket_port': apiopts.get('port', 8000),
                 'debug': apiopts.get('debug', False),
             },


### PR DESCRIPTION
I'm using salt-api as a bridge between Salt and a custom web interface. In this use case, I have no reason to make salt-api available outside of the server running salt-api and the web interface, so I've added this setting in to allow me to change the socket host to 127.0.0.1.

The default is still 0.0.0.0 (i.e. all interfaces).
