### PR TITLE
Made the new 'host' property actually optional

### DIFF
--- a/saltapi/netapi/rest_cherrypy/__init__.py
+++ b/saltapi/netapi/rest_cherrypy/__init__.py
@@ -92,7 +92,7 @@ def start():
                 apiopts['ssl_crt'], apiopts['ssl_key'])
         wsgi_d = wsgiserver.WSGIPathInfoDispatcher({'/': application})
         server = wsgiserver.CherryPyWSGIServer(
-                (apiopts['host'], apiopts['port']),
+                (apiopts.get('host', '0.0.0.0'), apiopts['port']),
                 wsgi_app=wsgi_d)
         server.ssl_adapter = ssl_a
 


### PR DESCRIPTION
Fixed a slip up in #89 where the new 'host' property wasn't actually optional. This PR makes it default to '0.0.0.0' if the 'host' property is not specified in the master configuration file.
