### PR TITLE
Added required attributes for cmd parser mixins after changes in Salt 0.15.9

### DIFF
--- a/saltapi/cli.py
+++ b/saltapi/cli.py
@@ -33,8 +33,13 @@ class SaltAPI(OptionParser, ConfigDirMixIn, LogLevelMixIn, PidfileMixin,
 
     VERSION = saltapi.version.__version__
 
+    # ConfigDirMixIn config filename attribute
+    _config_filename_ = 'master'
+    # LogLevelMixIn attributes
+    _default_logging_logfile_ = '/var/log/salt/api'
+
     def setup_config(self):
-        return saltapi.config.api_config(self.get_config_file_path('master'))
+        return saltapi.config.api_config(self.get_config_file_path())
 
     def run(self):
         '''

--- a/saltapi/config.py
+++ b/saltapi/config.py
@@ -8,7 +8,7 @@ import salt.config
 DEFAULT_API_OPTS = {
     # ----- Salt master settings overridden by Salt-API --------------------->
     'pidfile': '/var/run/salt-api.pid',
-    'logfile': '/var/log/api',
+    'logfile': '/var/log/salt/api',
     # <---- Salt master settings overridden by Salt-API ----------------------
 }
 


### PR DESCRIPTION
Without these changes, salt-api will not start when installed with Salt 0.15.9 (dies with an error saying _default_logging_logfile_ is not defined).

See Salt commits c3bfde339a and 92da051c00. Also moved the default logging location to /var/log/salt to bring it inline with the rest of the Salt logs.
