### PR TITLE
Add "-d" options to start salt-api

### DIFF
--- a/pkg/rpm/salt-api
+++ b/pkg/rpm/salt-api
@@ -65,7 +65,7 @@ start() {
             RETVAL=0
         fi
     else
-        daemon --check $SERVICE $SALTAPI $CONFIG_ARGS
+        daemon --check $SERVICE $SALTAPI -d $CONFIG_ARGS
     fi
     RETVAL=$?
     echo


### PR DESCRIPTION
In RHEL/CentOS, daemon should start in daemon mode, The salt-api will
start in frontgroud without "-d" options.
