### PR TITLE
Throw Error if lowstates aren't a list (instead of stack tracing). Old t...

### DIFF
--- a/saltapi/netapi/rest_cherrypy/app.py
+++ b/saltapi/netapi/rest_cherrypy/app.py
@@ -432,6 +432,10 @@ class LowDataAdapter(object):
         lowstate = cherrypy.request.lowstate
         token = cherrypy.session.get('token', None)
 
+        # if the lowstate loaded isn't a list, lets notify the client
+        if type(lowstate) != list:
+            raise cherrypy.HTTPError(400, 'Lowstates must be a list')
+
         for chunk in lowstate:
             if token:
                 chunk['token'] = token


### PR DESCRIPTION
...race was:

```
return: "Traceback (most recent call last):\n  File \"/usr/lib/python2.6/site-packages/saltapi/netapi/rest_cherrypy/app.py\"\
  , line 255, in hypermedia_handler\n    ret = cherrypy.serving.request._hypermedia_inner_handler(*args,\
  \ **kwargs)\n  File \"/usr/lib/python2.6/site-packages/cherrypy/_cpdispatch.py\"\
  , line 34, in __call__\n    return self.callable(*self.args, **self.kwargs)\n  File\
  \ \"/usr/lib/python2.6/site-packages/saltapi/netapi/rest_cherrypy/app.py\", line\
  \ 532, in POST\n    'return': list(self.exec_lowstate()),\n  File \"/usr/lib/python2.6/site-packages/saltapi/netapi/rest_cherrypy/app.py\"\
  , line 432, in exec_lowstate\n    chunk['token'] = token\nTypeError: 'unicode' object\
  \ does not support item assignment\n"
status: 500

```
