### PR TITLE
tools.cpstats.on needs to be placed under root

### DIFF
--- a/saltapi/netapi/rest_cherrypy/app.py
+++ b/saltapi/netapi/rest_cherrypy/app.py
@@ -1414,10 +1414,10 @@ class API(object):
 
                 'tools.trailing_slash.on': True,
                 'tools.gzip.on': True,
+                'tools.cpstats.on': self.apiopts.get('collect_stats', False),
             },
             '/stats': {
                 'request.dispatch': cherrypy.dispatch.Dispatcher(),
-                'tools.cpstats.on': self.apiopts.get('collect_stats', False),
             },
         }
 


### PR DESCRIPTION
Small error, tools.cpstats.on actually needs to be under root for metrics to be collected for all requests.
